### PR TITLE
fix to URLS trailing with \"onclick[...]

### DIFF
--- a/extension/background_scripts/downloader.js
+++ b/extension/background_scripts/downloader.js
@@ -252,7 +252,7 @@ browser.runtime.onMessage.addListener(async message => {
       if (options.useMoodleFileName && node.fileName !== "" && fileType !== "") {
         fileName = `${sanitizeFileName(node.fileName)}.${fileType}`
       }
-
+      downloadURL=downloadURL.replace(/\"\ onclick.*/gi, "") // fix trailing %22%20onclick issue
       await download(downloadURL, fileName, node.section)
     }
 


### PR DESCRIPTION
Simple fix to URLS trailing with \"onclick[...]:
 downloadURL=downloadURL.replace(/\"\ onclick.*/gi, "") // fix trailing %22%20onclick issue